### PR TITLE
Requires that `define` is a function before calling it

### DIFF
--- a/channels.js
+++ b/channels.js
@@ -48,7 +48,7 @@
     
     if (typeof module !== 'undefined' && module.exports) {
         module.exports = EventChannel
-    } else if (typeof define !== 'undefined') {
+    } else if (typeof define === 'function') {
         define('EventChannel', function () { return EventChannel })
     } else {
         this.EventChannel = EventChannel

--- a/events.js
+++ b/events.js
@@ -241,7 +241,7 @@
     
     if (typeof module !== 'undefined' && module.exports) {
         module.exports = EventEmitter
-    } else if (typeof define !== 'undefined') {
+    } else if (typeof define === 'function') {
         define('EventEmitter', function () { return EventEmitter })
     } else {
         this.EventEmitter = EventEmitter


### PR DESCRIPTION
Currently if `defined` is an object, a string, number or anything that's defined, this error happens:

```
Uncaught TypeError: (someType) is not a function
```
