### PR TITLE
Loop counter is being overwritten

### DIFF
--- a/evy.js
+++ b/evy.js
@@ -192,7 +192,7 @@
                 case 3: fn.call(context, arguments[1], arguments[2]); break
                 default: // args optimization borrowed from node EventEmitter (lib/events.js)
                     var args = new Array(length - 1)
-                    for (i = 1; i < length; i++) args[i - 1] = arguments[i]
+                    for (var j = 1; j < length; j++) args[j - 1] = arguments[j]
                     fn.apply(context, args)
             }
         }


### PR DESCRIPTION
We are overwriting a variable used in the loop of arguments on EventEmitter.prototype.emit, that goes through all the handlers, preventing some handlers from being called on the following case: "when we try to emit an event x-times less than number of arguments of the event"